### PR TITLE
Decode encoded query parameters before gin handler

### DIFF
--- a/gin/ginlambda_test.go
+++ b/gin/ginlambda_test.go
@@ -2,7 +2,10 @@ package ginadapter_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log"
+	"net/url"
 
 	"github.com/aws/aws-lambda-go/events"
 	ginadapter "github.com/awslabs/aws-lambda-go-api-proxy/gin"
@@ -110,6 +113,91 @@ var _ = Describe("GinLambdaALB tests", func() {
 
 			Expect(err).To(BeNil())
 			Expect(resp.StatusCode).To(Equal(200))
+		})
+	})
+
+	Context("Decoding query parameters", func() {
+		type tQuery struct {
+			Email string `url:"email" form:"email" json:"email"`
+		}
+		type tResp struct {
+			Error    string `json:"error"`
+			Received string `json:"received"`
+			Decoded  string `json:"decoded"`
+		}
+
+		It("Decodes query parameters from request correctly", func() {
+			log.Println("Starting test")
+
+			testCase := "some@site.com"
+			r := gin.Default()
+			r.GET("/users", func(c *gin.Context) {
+				log.Println("In the handler!!")
+
+				var q tQuery
+				err := c.ShouldBindQuery(&q)
+				if err != nil {
+					log.Printf("failed bind query: %s", err)
+					c.JSON(200, tResp{
+						Error:    fmt.Sprintf("failed bind query: %s", err),
+						Received: q.Email,
+					})
+					return
+				}
+
+				decoded, err := url.QueryUnescape(q.Email)
+				if err != nil {
+					log.Printf("failed to decode query parameter: %s", err)
+					c.JSON(200, tResp{
+						Error:    fmt.Sprintf("failed to decode query parameter: %s", err),
+						Received: q.Email,
+						Decoded:  decoded,
+					})
+					return
+				}
+
+				if q.Email != testCase {
+					log.Printf("parameter '%s is not as expected '%s'", q.Email, testCase)
+					c.JSON(200, tResp{
+						Error:    "parameter is not as expected",
+						Received: q.Email,
+						Decoded:  decoded,
+					})
+					return
+				}
+
+				c.JSON(200, tResp{
+					Received: q.Email,
+					Decoded:  decoded,
+				})
+			})
+
+			adapter := ginadapter.NewALB(r)
+
+			req := events.ALBTargetGroupRequest{
+				HTTPMethod: "GET",
+				Path:       "/users",
+				QueryStringParameters: map[string]string{
+					"email": url.QueryEscape(testCase),
+				},
+				RequestContext: events.ALBTargetGroupRequestContext{
+					ELB: events.ELBContext{TargetGroupArn: " ad"},
+				}}
+
+			resp, err := adapter.Proxy(req)
+
+			log.Printf("Body: %s\n", resp.Body)
+
+			Expect(err).To(BeNil())
+			Expect(resp.StatusCode).To(Equal(200))
+			Expect(resp.Body).To(Not(BeEmpty()))
+
+			var result tResp
+			err = json.Unmarshal([]byte(resp.Body), &result)
+			Expect(err).To(BeNil())
+
+			Expect(result.Received).To(Equal(testCase), fmt.Sprintf("expected: '%s', got: '%s', it should decoded: '%s'", testCase, result.Received, result.Decoded))
+			Expect(result.Error).To(BeEmpty(), result.Error)
 		})
 	})
 })


### PR DESCRIPTION
There is an internal url-encoding of query parameters when converting AWS event ALBTargetGroup into gin context. When parameters already encoded before sending to AWS lambda endpoint from react framerork, they are encoded twice and inside of gin request handler need to be decoded. Will be gret to have same functionality like nginx have - is to decode parameters before handler
